### PR TITLE
fix: login-form demo credentials match the hint

### DIFF
--- a/src/views/tools/LoginFormPage.vue
+++ b/src/views/tools/LoginFormPage.vue
@@ -47,7 +47,7 @@
           <span v-show="!isLoading">Sign In</span>
         </button>
 
-        <p class="hint">Use the demo credentials to sign in</p>
+        <p class="hint" data-testid="login-hint">Hint: admin / password123</p>
       </form>
     </div>
   </div>
@@ -86,7 +86,7 @@ export default {
       this.isLoading = true;
       this._loginTimer = setTimeout(() => {
         this.isLoading = false;
-        if (this.username === (process.env.VUE_APP_DEMO_USER || 'admin') && this.password === (process.env.VUE_APP_DEMO_PASS || 'demo-pass')) {
+        if (this.username === (process.env.VUE_APP_DEMO_USER || 'admin') && this.password === (process.env.VUE_APP_DEMO_PASS || 'password123')) {
           this.loginSuccess = true;
         } else {
           this.loginError = 'Invalid username or password';


### PR DESCRIPTION
## Summary
- Default demo password fallback was `demo-pass`, but the intended demo creds (shown in docs / used by test suites) are `admin / password123`. Tests waiting on `login-success` hung forever because `admin / password123` failed the credential check.
- The visible hint on the form said "Use the demo credentials to sign in" without showing what those credentials are, so a user could never actually sign in.

## Change
- `LoginFormPage.vue`:
  - Hint text: `"Use the demo credentials to sign in"` → `"Hint: admin / password123"` (with `data-testid="login-hint"`).
  - Default password fallback: `'demo-pass'` → `'password123'`.

## Test plan
- [ ] Visit `/login-form` → hint reads "Hint: admin / password123"
- [ ] Submit empty form → field-level validation errors shown
- [ ] Submit `wrong / wrongpass` → "Invalid username or password" shown
- [ ] Submit `admin / password123` → success message with `data-testid="login-success"`

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>