### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue-test-app",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-test-app",
-      "version": "0.1.3",
+      "version": "0.1.5",
       "dependencies": {
         "@vuepic/vue-datepicker": "^8.1.1",
         "core-js": "^3.37.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-test-app",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",


### PR DESCRIPTION
## Summary
- Version bump 0.1.4 → 0.1.5 for the login-form credentials fix shipped in #46.

Co-Authored-By: borealis.local <198563339+borealis-local@users.noreply.github.com>